### PR TITLE
feat: use slurm snap for slurmdbd operations 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,12 +64,16 @@ jobs:
 
   integration-test:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         bases:
           - ubuntu@22.04
-    name: Integration tests (LXD) | ${{ matrix.bases }}
+        local: [true, false]
+    name: Integration tests (LXD) ${{ matrix.local && '|' || '| Charmhub (edge) |'}} ${{ matrix.bases }}
     runs-on: ubuntu-latest
+    # Testing against Charmhub will probably yield errors when doing breaking changes, so don't
+    # block CI on that.
+    continue-on-error: ${{ !matrix.local }}
     needs:
       - inclusive-naming-check
       - lint
@@ -82,6 +86,7 @@ jobs:
           path: main
       - name: Fetch slurmctld
         uses: actions/checkout@v4
+        if: ${{ matrix.local }}
         with:
           repository: charmed-hpc/slurmctld-operator
           path: slurmctld-operator
@@ -91,4 +96,7 @@ jobs:
           provider: lxd
           juju-channel: 3.4/stable
       - name: Run tests
-        run: cd main && tox run -e integration -- --charm-base=${{ matrix.bases }} --use-local
+        run: |
+          cd main && tox run -e integration -- \
+             --charm-base=${{ matrix.bases }} \
+             ${{ matrix.local && '--use-local' || '' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        bases:          
+        bases:
           - ubuntu@22.04
     name: Integration tests (LXD) | ${{ matrix.bases }}
     runs-on: ubuntu-latest
@@ -78,10 +78,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          path: main
+      - name: Fetch slurmctld
+        uses: actions/checkout@v4
+        with:
+          repository: charmed-hpc/slurmctld-operator
+          path: slurmctld-operator
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          juju-channel: 3.1/stable
+          juju-channel: 3.4/stable
       - name: Run tests
-        run: tox run -e integration -- --charm-base=${{ matrix.bases }}
+        run: cd main && tox run -e integration -- --charm-base=${{ matrix.bases }} --use-local

--- a/.github/workflows/experimental.yaml
+++ b/.github/workflows/experimental.yaml
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: slurmdbd charm tests
+name: slurmdbd charm tests (experimental)
 on:
-  workflow_call:
   pull_request:
     branches:
-      - main
+      - experimental
 
 jobs:
   inclusive-naming-check:
@@ -66,16 +65,12 @@ jobs:
 
   integration-test:
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         bases:
           - ubuntu@22.04
-        local: [true, false]
-    name: Integration tests (LXD) ${{ matrix.local && '|' || '| Charmhub (edge) |'}} ${{ matrix.bases }}
+    name: Integration tests (LXD) | ${{ matrix.bases }}
     runs-on: ubuntu-latest
-    # Testing against Charmhub will probably yield errors when doing breaking changes, so don't
-    # block CI on that.
-    continue-on-error: ${{ !matrix.local }}
     needs:
       - inclusive-naming-check
       - lint
@@ -88,10 +83,10 @@ jobs:
           path: main
       - name: Fetch slurmctld
         uses: actions/checkout@v4
-        if: ${{ matrix.local }}
         with:
           repository: charmed-hpc/slurmctld-operator
           path: slurmctld-operator
+          ref: experimental
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -101,4 +96,4 @@ jobs:
         run: |
           cd main && tox run -e integration -- \
              --charm-base=${{ matrix.bases }} \
-             ${{ matrix.local && '--use-local' || '' }}
+             --use-local

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,10 +32,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.2.0
+        uses: canonical/charming-actions/channel@2.5.0-rc
         id: channel
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.2.0
+        uses: canonical/charming-actions/upload-charm@2.5.0-rc
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/lib/charms/hpc_libs/v0/slurm_ops.py
+++ b/lib/charms/hpc_libs/v0/slurm_ops.py
@@ -1,0 +1,308 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Abstractions for managing Slurm operations via snap.
+
+This library contains the `SlurmManagerBase` and `ServiceType` class
+which provide high-level interfaces for managing Slurm within charmed operators.
+
+### Example Usage
+
+#### Managing a Slurm service
+
+The `SlurmManagerBase` constructor receives a `ServiceType` enum. The enum instructs
+the inheriting Slurm service manager how to manage its corresponding Slurm service on the host.
+
+```python3
+import charms.hpc_libs.v0.slurm_ops as slurm
+from charms.hpc_libs.v0.slurm_ops import SlurmManagerBase, ServiceType
+
+class SlurmctldManager(SlurmManagerBase):
+    # Manage `slurmctld` service on host.
+
+    def __init__(self) -> None:
+        super().__init__(ServiceType.SLURMCTLD)
+
+
+class ApplicationCharm(CharmBase):
+    # Application charm that needs to use the Slurm snap.
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        self._slurm_manager = SlurmctldManager()
+        self.framework.observe(
+            self.on.install,
+            self._on_install,
+        )
+
+    def _on_install(self, _) -> None:
+        slurm.install()
+        self.unit.set_workload_version(slurm.version())
+        self._slurm_manager.config.set({"cluster-name": "cluster"})
+```
+"""
+
+__all__ = [
+    "format_key",
+    "install",
+    "version",
+    "ConfigurationManager",
+    "ServiceType",
+    "SlurmManagerBase",
+    "SlurmOpsError",
+]
+
+import json
+import logging
+import re
+import socket
+import subprocess
+from collections.abc import Mapping
+from enum import Enum
+from typing import Any, Optional
+
+import yaml
+
+# The unique Charmhub library identifier, never change it
+LIBID = "541fd767f90b40539cf7cd6e7db8fabf"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 5
+
+# Charm library dependencies to fetch during `charmcraft pack`.
+PYDEPS = ["pyyaml>=6.0.1"]
+
+_logger = logging.getLogger(__name__)
+_acronym = re.compile(r"(?<=[A-Z])(?=[A-Z][a-z])")
+_kebabize = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+
+
+class SlurmOpsError(Exception):
+    """Exception raised when a slurm operation failed."""
+
+    @property
+    def message(self) -> str:
+        """Return message passed as argument to exception."""
+        return self.args[0]
+
+
+def format_key(key: str) -> str:
+    """Format Slurm configuration keys from SlurmCASe into kebab case.
+
+    Args:
+        key: Slurm configuration key to convert to kebab case.
+
+    Notes:
+       Slurm configuration syntax does not follow proper PascalCasing
+       format, so we cannot put keys directly through a kebab case converter
+       to get the desired format. Some additional processing is needed for
+       certain keys before the key can properly kebabized.
+
+       For example, without additional preprocessing, the key `CPUs` will
+       become `cp-us` if put through a kebabizer with being preformatted to `Cpus`.
+    """
+    if "CPUs" in key:
+        key = key.replace("CPUs", "Cpus")
+    key = _acronym.sub(r"-", key)
+    return _kebabize.sub(r"-", key).lower()
+
+
+def install() -> None:
+    """Install Slurm."""
+    # FIXME: Pin slurm to the stable channel
+    _snap("install", "slurm", "--channel", "latest/candidate", "--classic")
+
+
+def version() -> str:
+    """Get the current version of Slurm installed on the system."""
+    info = yaml.safe_load(_snap("info", "slurm"))
+    if (ver := info.get("installed")) is None:
+        raise SlurmOpsError("unable to retrive snap info. Ensure slurm is correctly installed")
+    return ver.split(maxsplit=1)[0]
+
+
+def _call(cmd: str, *args: str, stdin: Optional[str] = None) -> str:
+    """Call a command with logging.
+
+    Raises:
+        SlurmOpsError: Raised if the command fails.
+    """
+    cmd = [cmd, *args]
+    _logger.debug(f"Executing command {cmd}")
+    try:
+        return subprocess.check_output(cmd, input=stdin, stderr=subprocess.PIPE, text=True).strip()
+    except subprocess.CalledProcessError as e:
+        _logger.error(f"`{' '.join(cmd)}` failed")
+        _logger.error(f"stderr: {e.stderr.decode()}")
+        raise SlurmOpsError(f"command {cmd[0]} failed. Reason:\n{e.stderr.decode()}")
+
+
+def _snap(*args) -> str:
+    """Control snap by via executed `snap ...` commands.
+
+    Raises:
+        subprocess.CalledProcessError: Raised if snap command fails.
+    """
+    return _call("snap", *args)
+
+
+def _mungectl(*args: str, stdin: Optional[str] = None) -> str:
+    """Control munge via `slurm.mungectl ...`.
+
+    Args:
+        *args: Arguments to pass to `mungectl`.
+        stdin: Input to pass to `mungectl` via stdin.
+
+    Raises:
+        subprocess.CalledProcessError: Raised if `mungectl` command fails.
+    """
+    return _call("slurm.mungectl", *args, stdin=stdin)
+
+
+class ServiceType(Enum):
+    """Type of Slurm service to manage."""
+
+    MUNGED = "munged"
+    PROMETHEUS_EXPORTER = "slurm-prometheus-exporter"
+    SLURMD = "slurmd"
+    SLURMCTLD = "slurmctld"
+    SLURMDBD = "slurmdbd"
+    SLURMRESTD = "slurmrestd"
+
+    @property
+    def config_name(self) -> str:
+        """Configuration name on the slurm snap for this service type."""
+        if self is ServiceType.SLURMCTLD:
+            return "slurm"
+        if self is ServiceType.MUNGED:
+            return "munge"
+
+        return self.value
+
+
+class ServiceManager:
+    """Control a Slurm service."""
+
+    def enable(self) -> None:
+        """Enable service."""
+        _snap("start", "--enable", f"slurm.{self._service.value}")
+
+    def disable(self) -> None:
+        """Disable service."""
+        _snap("stop", "--disable", f"slurm.{self._service.value}")
+
+    def restart(self) -> None:
+        """Restart service."""
+        _snap("restart", f"slurm.{self._service.value}")
+
+    def active(self) -> bool:
+        """Return True if the service is active."""
+        info = yaml.safe_load(_snap("info", "slurm"))
+        if (services := info.get("services")) is None:
+            raise SlurmOpsError("unable to retrive snap info. Ensure slurm is correctly installed")
+
+        # Assume `services` contains the service, since `ServiceManager` is not exposed as a
+        # public interface for now.
+        # We don't do `"active" in state` because the word "active" is also part of "inactive" :)
+        return "inactive" not in services[f"slurm.{self._service.value}"]
+
+
+class ConfigurationManager:
+    """Control configuration of a Slurm component."""
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def get_options(self, *keys: str) -> Mapping[str, Any]:
+        """Get given configurations values for Slurm component."""
+        configs = {}
+        for key in keys:
+            config = self.get(key)
+            target = key.rsplit(".", maxsplit=1)[-1]
+            configs[target] = config
+
+        return configs
+
+    def get(self, key: Optional[str] = None) -> Any:
+        """Get specific configuration value for Slurm component."""
+        key = f"{self._name}.{key}" if key else self._name
+        config = json.loads(_snap("get", "-d", "slurm", key))
+        return config[key]
+
+    def set(self, config: Mapping[str, Any]) -> None:
+        """Set configuration for Slurm component."""
+        args = [f"{self._name}.{k}={json.dumps(v)}" for k, v in config.items()]
+        _snap("set", "slurm", *args)
+
+    def unset(self, *keys: str) -> None:
+        """Unset configuration for Slurm component."""
+        args = [f"{self._name}.{k}" for k in keys] if len(keys) > 0 else [self._name]
+        _snap("unset", "slurm", *args)
+
+
+class MungeManager(ServiceManager):
+    """Manage `munged` service operations."""
+
+    def __init__(self) -> None:
+        service = ServiceType.MUNGED
+        self._service = service
+        self.config = ConfigurationManager(service.config_name)
+
+    def get_key(self) -> str:
+        """Get the current munge key.
+
+        Returns:
+            The current munge key as a base64-encoded string.
+        """
+        return _mungectl("key", "get")
+
+    def set_key(self, key: str) -> None:
+        """Set a new munge key.
+
+        Args:
+            key: A new, base64-encoded munge key.
+        """
+        _mungectl("key", "set", stdin=key)
+
+    def generate_key(self) -> None:
+        """Generate a new, cryptographically secure munge key."""
+        _mungectl("key", "generate")
+
+
+class PrometheusExporterManager(ServiceManager):
+    """Manage `slurm-prometheus-exporter` service operations."""
+
+    def __init__(self) -> None:
+        self._service = ServiceType.PROMETHEUS_EXPORTER
+
+
+class SlurmManagerBase(ServiceManager):
+    """Base manager for Slurm services."""
+
+    def __init__(self, service: ServiceType) -> None:
+        self._service = service
+        self.config = ConfigurationManager(service.config_name)
+        self.munge = MungeManager()
+        self.exporter = PrometheusExporterManager()
+
+    @property
+    def hostname(self) -> str:
+        """The hostname where this manager is running."""
+        return socket.gethostname().split(".")[0]

--- a/src/charm.py
+++ b/src/charm.py
@@ -102,7 +102,12 @@ class SlurmdbdCharm(CharmBase):
             self._slurmdbd_ops_manager.write_munge_key(munge_key)
             self._slurmdbd_ops_manager.start_munge()
 
-        self._write_config_and_restart_slurmdbd(event)
+        # Don't try to write the config before the database has been created.
+        # Otherwise, this will trigger a defer on this event, which we don't really need
+        # or the munge service will restart too many times, triggering a restart limit on
+        # systemctl.
+        if self._stored.db_info:
+            self._write_config_and_restart_slurmdbd(event)
 
     def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
         """Process the DatabaseCreatedEvent and updates the database parameters.

--- a/src/constants.py
+++ b/src/constants.py
@@ -3,55 +3,24 @@
 """Constants."""
 from pathlib import Path
 
-SLURM_USER = "slurm"
-SLURM_GROUP = "slurm"
+_SNAP_COMMON = Path("/var/snap/slurm/common")
 
-STATE_DIR = Path("/var/spool/slurmdbd")
+SLURM_USER = "root"
+SLURM_GROUP = "root"
+
+SLURMDBD_CONF_PATH = _SNAP_COMMON / "etc/slurm/slurmdbd.conf"
+SPOOL_DIR = _SNAP_COMMON / "var/lib/slurm/slurmdbd"
+SLURMDBD_DEFAULTS_FILE = _SNAP_COMMON / "etc/default/slurmdbd"
+JWT_RSA_PATH = SPOOL_DIR / "jwt_hs256.key"
+
+SLURM_ACCT_DB = "slurm_acct_db"
 
 CHARM_MAINTAINED_PARAMETERS = {
     "DbdPort": "6819",
     "AuthType": "auth/munge",
-    "AuthInfo": '"socket=/var/run/munge/munge.socket.2"',
+    "AuthInfo": f'"socket={_SNAP_COMMON}/run/munge/munged.socket.2"',
     "SlurmUser": SLURM_USER,
-    "PluginDir": "/usr/lib/x86_64-linux-gnu/slurm-wlm",
-    "PidFile": "/var/run/slurmdbd.pid",
-    "LogFile": "/var/log/slurm/slurmdbd.log",
+    "PidFile": f"{_SNAP_COMMON}/run/slurmdbd.pid",
+    "LogFile": f"{_SNAP_COMMON}/var/log/slurm/slurmdbd.log",
     "StorageType": "accounting_storage/mysql",
 }
-
-SLURM_ACCT_DB = "slurm_acct_db"
-
-SLURMDBD_DEFAULTS_FILE = Path("/etc/default/slurmdbd")
-
-UBUNTU_HPC_PPA_KEY = """
------BEGIN PGP PUBLIC KEY BLOCK-----
-Comment: Hostname:
-Version: Hockeypuck 2.1.1-10-gec3b0e7
-
-xsFNBGTuZb8BEACtJ1CnZe6/hv84DceHv+a54y3Pqq0gqED0xhTKnbj/E2ByJpmT
-NlDNkpeITwPAAN1e3824Me76Qn31RkogTMoPJ2o2XfG253RXd67MPxYhfKTJcnM3
-CEkmeI4u2Lynh3O6RQ08nAFS2AGTeFVFH2GPNWrfOsGZW03Jas85TZ0k7LXVHiBs
-W6qonbsFJhshvwC3SryG4XYT+z/+35x5fus4rPtMrrEOD65hij7EtQNaE8owuAju
-Kcd0m2b+crMXNcllWFWmYMV0VjksQvYD7jwGrWeKs+EeHgU8ZuqaIP4pYHvoQjag
-umqnH9Qsaq5NAXiuAIAGDIIV4RdAfQIR4opGaVgIFJdvoSwYe3oh2JlrLPBlyxyY
-dayDifd3X8jxq6/oAuyH1h5K/QLs46jLSR8fUbG98SCHlRmvozTuWGk+e07ALtGe
-sGv78ToHKwoM2buXaTTHMwYwu7Rx8LZ4bZPHdersN1VW/m9yn1n5hMzwbFKy2s6/
-D4Q2ZBsqlN+5aW2q0IUmO+m0GhcdaDv8U7RVto1cWWPr50HhiCi7Yvei1qZiD9jq
-57oYZVqTUNCTPxi6NeTOdEc+YqNynWNArx4PHh38LT0bqKtlZCGHNfoAJLPVYhbB
-b2AHj9edYtHU9AAFSIy+HstET6P0UDxy02IeyE2yxoUBqdlXyv6FL44E+wARAQAB
-zRxMYXVuY2hwYWQgUFBBIGZvciBVYnVudHUgSFBDwsGOBBMBCgA4FiEErocSHcPk
-oLD4H/Aj9tDF1ca+s3sFAmTuZb8CGwMFCwkIBwIGFQoJCAsCBBYCAwECHgECF4AA
-CgkQ9tDF1ca+s3sz3w//RNawsgydrutcbKf0yphDhzWS53wgfrs2KF1KgB0u/H+u
-6Kn2C6jrVM0vuY4NKpbEPCduOj21pTCepL6PoCLv++tICOLVok5wY7Zn3WQFq0js
-Iy1wO5t3kA1cTD/05v/qQVBGZ2j4DsJo33iMcQS5AjHvSr0nu7XSvDDEE3cQE55D
-87vL7lgGjuTOikPh5FpCoS1gpemBfwm2Lbm4P8vGOA4/witRjGgfC1fv1idUnZLM
-TbGrDlhVie8pX2kgB6yTYbJ3P3kpC1ZPpXSRWO/cQ8xoYpLBTXOOtqwZZUnxyzHh
-gM+hv42vPTOnCo+apD97/VArsp59pDqEVoAtMTk72fdBqR+BB77g2hBkKESgQIEq
-EiE1/TOISioMkE0AuUdaJ2ebyQXugSHHuBaqbEC47v8t5DVN5Qr9OriuzCuSDNFn
-6SBHpahN9ZNi9w0A/Yh1+lFfpkVw2t04Q2LNuupqOpW+h3/62AeUqjUIAIrmfeML
-IDRE2VdquYdIXKuhNvfpJYGdyvx/wAbiAeBWg0uPSepwTfTG59VPQmj0FtalkMnN
-ya2212K5q68O5eXOfCnGeMvqIXxqzpdukxSZnLkgk40uFJnJVESd/CxHquqHPUDE
-fy6i2AnB3kUI27D4HY2YSlXLSRbjiSxTfVwNCzDsIh7Czefsm6ITK2+cVWs0hNQ=
-=cs1s
------END PGP PUBLIC KEY BLOCK-----
-"""

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -71,7 +71,7 @@ async def test_build_and_deploy_against_edge(
         ),
     )
     # Set relations for charmed applications.
-    await ops_test.model.integrate(f"{SLURMDBD}:{SLURMDBD}", f"{SLURMCTLD}:{SLURMDBD}")
+    await ops_test.model.integrate(f"{SLURMDBD}:{SLURMCTLD}", f"{SLURMCTLD}:{SLURMDBD}")
     await ops_test.model.integrate(f"{ROUTER}:backend-database", f"{DATABASE}:database")
     await ops_test.model.integrate(f"{SLURMDBD}:database", f"{ROUTER}:database")
     # Reduce the update status frequency to accelerate the triggering of deferred events.

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -91,7 +91,7 @@ async def test_slurmdbd_is_active(ops_test: OpsTest) -> None:
     """Test that slurmdbd is active inside Juju unit."""
     logger.info("Checking that slurmdbd daemon is active inside unit")
     slurmdbd_unit = ops_test.model.units.get(UNIT_NAME)
-    res = (await slurmdbd_unit.ssh("systemctl is-active slurmdbd")).strip("\n")
+    res = (await slurmdbd_unit.ssh("systemctl is-active snap.slurm.slurmdbd")).strip("\n")
     assert res == "active"
 
 
@@ -121,5 +121,5 @@ async def test_munge_is_active(ops_test: OpsTest) -> None:
     """Test that munge is active inside Juju unit."""
     logger.info("Checking that munge is active inside Juju unit")
     slurmdbd_unit = ops_test.model.units.get(UNIT_NAME)
-    res = (await slurmdbd_unit.ssh("systemctl is-active munge")).strip("\n")
+    res = (await slurmdbd_unit.ssh("systemctl is-active snap.slurm.munged")).strip("\n")
     assert res == "active"

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ env_list = lint, type, unit
 [vars]
 src_path = {toxinidir}/src
 tst_path = {toxinidir}/tests
-all_path = {[vars]src_path} {[vars]tst_path} 
+all_path = {[vars]src_path} {[vars]tst_path}
 
 [testenv]
 setenv =


### PR DESCRIPTION
## Description

Uses the `slurm_ops` library to manage slurmdbd.
Adds support for running CI 

## How was the code tested?

Locally on an Ubuntu Jammy development machine.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [ ] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
