### PR TITLE
fix: set `AuthAltTypes="auth/jwt" for jwt authentication

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -247,6 +247,7 @@ class SlurmdbdCharm(CharmBase):
             }
 
             if self._slurmctld.is_joined:
+                slurmdbd_full_config["AuthAltTypes"] = "auth/jwt"
                 slurmdbd_full_config["AuthAltParameters"] = (
                     '"jwt_key=/var/spool/slurmdbd/jwt_hs256.key"'
                 )


### PR DESCRIPTION
## Description

This enables using `slurmrestd` to comunicate with `slurmdbd`.

## How was the code tested?

Locally on an Ubuntu Noble development machine.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [x] All requested changes and/or review comments have been resolved.
